### PR TITLE
batman: change hardcoded cpu0 to ${CORE_FIRST}

### DIFF
--- a/src/batman
+++ b/src/batman
@@ -125,9 +125,9 @@ fi
 
 # Check if powersave governor is available.
 if [ "${LEGACY}" = "true" ] && [ -z "${CPUSAVEGOVERNOR}" ]; then
-   if grep -q powersave /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors; then
+   if grep -q powersave /sys/devices/system/cpu/cpu"${CORE_FIRST}"/cpufreq/scaling_available_governors; then
       CPUSAVEGOVERNOR="powersave"
-   elif grep -q userspace /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors; then
+   elif grep -q userspace /sys/devices/system/cpu/cpu"${CORE_FIRST}"/cpufreq/scaling_available_governors; then
       CPUSAVEGOVERNOR="userspace"
    else
       echo "powersave or userspace are not available governors on this system. exiting"
@@ -813,7 +813,7 @@ do
 
     # Save the current governor (check what has happened in the last run) so that if it is set to powersave we can use this info in our cpu offlining.
     if [ -z "${RUNTIME_CUR_GOVERNOR}" ]; then
-       CUR_GOVERNOR="$(</sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)"
+       CUR_GOVERNOR="$(</sys/devices/system/cpu/cpu"${CORE_FIRST}"/cpufreq/scaling_governor)"
     else
        CUR_GOVERNOR="${RUNTIME_CUR_GOVERNOR}"
     fi


### PR DESCRIPTION
A hardcoded cpu0 path in would cause batman to exit on the OnePlus 3/3T because when a core is offline, the cpufreq path doesn't exist for that core.
Changing this to ${CORE_FIRST} will instead check from an online core and not a potentially offlined one.