### PR TITLE
Add functionality to create state file and read states on startup

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -109,6 +109,7 @@ Depends: ${misc:Depends},
          python3-dbus,
          python3-gi,
          python3-dbus-next,
+         gir1.2-gtherm-0.0,
 Conflicts: power-profiles-daemon
 Description: batman2ppd
  A battery management service for Linux phones - batman to power profiles daemon service

--- a/src/batman2ppd.py
+++ b/src/batman2ppd.py
@@ -12,6 +12,13 @@ import subprocess
 import asyncio
 import time
 import os
+import configparser
+
+import gi
+gi.require_version('Gio', '2.0')
+from gi.repository import Gio
+gi.require_version('GTherm', '0.0')
+from gi.repository import GTherm
 
 class PPDInterface(ServiceInterface):
     def __init__(self, loop, bus):
@@ -24,7 +31,7 @@ class PPDInterface(ServiceInterface):
             'PerformanceDegraded': Variant('s', ''),
             'Profiles': Variant('aa{sv}', [{'Profile': Variant('s', 'power-saver'), 'Driver': Variant('s', 'batman')}, {'Profile': Variant('s', 'balanced'), 'Driver': Variant('s', 'batman')}, {'Profile': Variant('s', 'performance'), 'Driver': Variant('s', 'batman')}]),
             'Actions': Variant('as', ['trickle_charge']),
-            'ActiveProfilesHolds': Variant('aa{sv}', [])
+            'ActiveProfileHolds': Variant('aa{sv}', [])
         }
 
     @dbus_property(access=PropertyAccess.READWRITE)
@@ -39,7 +46,7 @@ class PPDInterface(ServiceInterface):
         else:
             default_governor = ""
 
-        if profile == "performance":
+        if profile == "performance" and self.props['PerformanceDegraded'].value == "":
             subprocess.Popen("batman-hybris vr 1", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
             if default_governor:
@@ -68,6 +75,8 @@ class PPDInterface(ServiceInterface):
                     subprocess.Popen("systemctl restart batman", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         self.props['ActiveProfile'] = Variant('s', profile)
+        self.SetProfile(profile)
+
 
     @dbus_property(access=PropertyAccess.READ)
     def PerformanceInhibited(self) -> 's':
@@ -87,7 +96,7 @@ class PPDInterface(ServiceInterface):
 
     @dbus_property(access=PropertyAccess.READ)
     def ActiveProfileHolds(self) -> 'aa{sv}':
-        return []
+        return self.props['ActiveProfileHolds'].value
 
     @method()
     def HoldProfile(self, profile: 's', reason: 's', application_id: 's'):
@@ -101,12 +110,130 @@ class PPDInterface(ServiceInterface):
     def InhibitDevice(self, uid: 's', inhibit: 'b'):
         pass
 
+    async def GetThermal(self):
+        i = 0
+        temp_total = 0
+        temp_avg = 0
+
+        os.seteuid(32011)
+        os.environ['DBUS_SESSION_BUS_ADDRESS'] = "unix:path=/run/user/32011/bus"
+
+        con = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        manager = GTherm.Manager.new_sync(con, 0, None)
+
+        for d in manager.get_thermal_zones():
+            raw_temperature = d.get_temperature()
+            temperature_celsius = raw_temperature / 1000.0
+            # most devices (exynos chipsets being one of them) show a bunch of useless nodes under 10c
+            # the temperature reading here is incorrect. instead of going through each kernel one by one
+            # we know that anything below 5-10C is basically impossible under normal usage and environment.
+            # this is not a perfect solution but should be good enough for now.
+            if temperature_celsius > 10:
+                #print(d.get_type_())
+                #print(f"{temperature_celsius:.1f}C")
+                temp_total = temp_total + temperature_celsius
+                i += 1
+
+        if os.getuid() == 0:
+            os.seteuid(0)
+
+        del os.environ['DBUS_SESSION_BUS_ADDRESS']
+
+        temp_avg = temp_total / i
+        #print(f"Average sys temp: {temp_avg:.1f}C")
+        return temp_avg
+
+    def UpdatePerformanceDegraded(self, temp_avg):
+        if temp_avg > 50:
+            self.props['PerformanceDegraded'] = Variant('s', 'high-operating-temperature')
+        else:
+            self.props['PerformanceDegraded'] = Variant('s', '')
+
+    def CreateStateFile(self):
+        directory = "/var/lib/power-profiles-daemon/"
+        file_path = os.path.join(directory, "state.ini")
+
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+        config = configparser.ConfigParser()
+
+        if not os.path.isfile(file_path):
+            config['State'] = {'Driver': 'batman', 'Profile': 'balanced'}
+
+            with open(file_path, 'w') as stateFile:
+                config.write(stateFile)
+        else:
+            config.read(file_path)
+            if not config.has_option('State', 'Driver') or not config.has_option('State', 'Profile'):
+                config['State'] = {'Driver': 'batman', 'Profile': 'balanced'}
+                with open(file_path, 'w') as stateFile:
+                    config.write(stateFile)
+
+    def StatesExist(self, file_path):
+        return os.path.isfile(file_path)
+
+    def SetState(self, driver, profile):
+        directory = "/var/lib/power-profiles-daemon/"
+        file_path = os.path.join(directory, "state.ini")
+        config = configparser.ConfigParser()
+        if not self.StatesExist(file_path):
+            config["State"] = {'Driver': driver, 'Profile': profile}
+            with open(file_path, 'w') as stateFile:
+                config.write(stateFile)
+        else:
+            config.read(file_path)
+            config.set('State', 'Driver', driver)
+            config.set('State', 'Profile', profile)
+            with open(file_path, 'w') as stateFile:
+                config.write(stateFile)
+
+    def SetProfile(self, profile):
+        directory = "/var/lib/power-profiles-daemon/"
+        file_path = os.path.join(directory, "state.ini")
+        config = configparser.ConfigParser()
+        if not self.StatesExist(file_path):
+            config["State"] = {'Profile': profile}
+            with open(file_path, 'w') as stateFile:
+                config.write(stateFile)
+        else:
+            config.read(file_path)
+            config.set('State', 'Profile', profile)
+            with open(file_path, 'w') as stateFile:
+                config.write(stateFile)
+    
+    def GetProfile(self):
+        directory = "/var/lib/power-profiles-daemon/"
+        file_path = os.path.join(directory, "state.ini")
+        config = configparser.ConfigParser()
+        if self.StatesExist(file_path):
+            try:
+                profile = config.get('State', 'Profile')
+            except configparser.NoSectionError:
+                profile = None
+            return profile
+        
 async def main():
     bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
     loop = asyncio.get_running_loop()
     ppd_interface = PPDInterface(loop, bus)
     bus.export('/net/hadess/PowerProfiles', ppd_interface)
     await bus.request_name('net.hadess.PowerProfiles')
+
+    async def thermal_check():
+        while True:
+            temp_avg = await ppd_interface.GetThermal()
+            ppd_interface.UpdatePerformanceDegraded(temp_avg)
+            await asyncio.sleep(5)
+
+    ppd_interface.CreateStateFile()
+
+    if ppd_interface.GetProfile():
+        profile = ppd_interface.GetProfile()
+        ppd_interface.ActiveProfile(profile)
+
+    loop.create_task(thermal_check())
+
     await bus.wait_for_disconnect()
 
 asyncio.run(main())


### PR DESCRIPTION
Added methods to create state file: CreateStateFile will create the state file with a default of 'Driver': 'batman', 'Profile': 'balanced'.
SetState will set states in the file. It takes in the driver and profile as arguments.
Profile setter and getter have also been added.
GetThermal uses gth to get thermal zones and average temperature. 
UpdatePerformanceDegraded uses temp_avg to update the PerformanceDegraded property.
The Async function(thermal_check) runs every 5 seconds in the main to keep temp_avg monitoring.
If there's a state file on startups, it will set the profile to the existing one.